### PR TITLE
verify added

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ lazy_static = "1.0"
 
 [dev-dependencies]
 serde_json = "1.0"
+rand = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ rustc-hex = "2.0"
 secp256k1 = "0.12"
 serde = { version = "1.0", features = ["derive"]}
 parity-crypto = "0.3"
+lazy_static = "1.0"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/tomusdrw/ethsign"
 version = "0.4.0"
 
 [dependencies]
-lazy_static = "1.0"
 libsecp256k1 = { package = "libsecp256k1", version = "0.2.2", optional = true }
 memzero = "0.1"
 parity-crypto = "0.3"

--- a/src/ec.rs
+++ b/src/ec.rs
@@ -17,7 +17,7 @@ mod secp256k1 {
     pub fn secret_to_public(secret: &[u8]) -> Result<[u8; 65], Error> {
         let sec = secp256k1::SecretKey::from_slice(secret)?;
         let pubkey = secp256k1::PublicKey::from_secret_key(&SECP256K1, &sec);
-        
+
         Ok(pubkey.serialize_uncompressed())
     }
 
@@ -47,7 +47,7 @@ mod secp256k1 {
         let sig = to_recoverable_signature(v, r, s)?;
         let msg = secp256k1::Message::from_slice(message)?;
         let pubkey = SECP256K1.recover(&msg, &sig)?;
-        
+
         Ok(pubkey.serialize_uncompressed())
     }
 
@@ -127,10 +127,9 @@ mod secp256k1 {
     /// Checks ECDSA validity of `signature(r, s)` for `message` with `public` key.
     /// Returns `Ok(true)` on success.
     pub fn verify(public: &[u8], _v: u8, r: &[u8; 32], s: &[u8; 32], message: &[u8]) -> Result<bool, Error> {
-        let pubkey = libsecp256k1::PublicKey::from_slice(public)?;
         let sig= to_signature(r, s);
-        let msg = libsecp256k1::Message::from_slice(message)?;
+        let msg = libsecp256k1::Message::parse_slice(message)?;
 
-        Ok(libsecp256k1::verify(&msg, &sig, &pubkey))
+        Ok(libsecp256k1::verify(&msg, &sig, &to_pubkey(public)?))
     }
 }

--- a/src/ec.rs
+++ b/src/ec.rs
@@ -66,7 +66,6 @@ mod secp256k1 {
         match SECP256K1.verify(&msg, &sig, &to_pubkey(public)?) {
             Ok(_) => Ok(true),
             Err(Error::IncorrectSignature) => Ok(false),
-            Err(Error::InvalidPublicKey) => Ok(false),
             Err(e) => Err(e)
         }
     }

--- a/src/key.rs
+++ b/src/key.rs
@@ -84,7 +84,7 @@ impl PublicKey {
 
     /// Checks ECDSA validity of `signature` for `message` with this public key.
     /// Returns `Ok(true)` on success.
-    pub fn verify(self, signature: &Signature, message: &[u8]) -> Result<bool, ec::Error> {
+    pub fn verify(&self, signature: &Signature, message: &[u8]) -> Result<bool, ec::Error> {
         ec::verify(&self.public, signature.v, &signature.r, &signature.s, message)
     }
 }


### PR DESCRIPTION
Hey,
it's a great small crate. Thanks for it.

From its name, I guess that it is meant to support `sign` op, but `verify` is complementary, so I'm proposing to add it. 
