### PR TITLE
Cargo feature to switch to pure Rust libsecp256k1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,4 @@ matrix:
 before_script:
   - rustup toolchain install stable
 
-script:
-  - cargo build
-  - cargo test
+script: ./test.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/tomusdrw/ethsign"
 version = "0.1.3"
 
 [dependencies]
+rand = "0.6"
 rustc-hex = "2.0"
 secp256k1 = { version = "0.12", optional = true }
 libsecp256k1 = { package = "libsecp256k1", version = "0.2.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/tomusdrw/ethsign"
 license = "GPL-3.0"
 name = "ethsign"
 repository = "https://github.com/tomusdrw/ethsign"
-version = "0.1.3"
+version = "0.2.0"
 
 [dependencies]
 rand = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,20 @@ version = "0.1.3"
 
 [dependencies]
 rustc-hex = "2.0"
-secp256k1 = "0.12"
+secp256k1 = { version = "0.12", optional = true }
+libsecp256k1 = { package = "libsecp256k1", version = "0.2.2", optional = true }
 serde = { version = "1.0", features = ["derive"]}
 parity-crypto = "0.3"
 
 [dev-dependencies]
 serde_json = "1.0"
+
+
+[features]
+default = ["secp256k1-c"]
+
+# Use the `secp256k1` crate which links to C code
+secp256k1-c = ["secp256k1"]
+
+# Use pure rust implementation of the `libsecp256k1`
+secp256k1-rs = ["libsecp256k1"]

--- a/src/ec.rs
+++ b/src/ec.rs
@@ -1,0 +1,119 @@
+pub use self::secp256k1::*;
+
+#[cfg(feature = "secp256k1-c")]
+pub mod secp256k1 {
+    pub type Error = secp256k1::Error;
+
+    pub fn verify_secret(secret: &[u8]) -> Result<(), Error> {
+        secp256k1::SecretKey::from_slice(secret)?;
+        Ok(())
+    }
+
+    pub fn secret_to_public(secret: &[u8]) -> Result<[u8; 65], Error> {
+        use secp256k1::{SecretKey, PublicKey, Secp256k1};
+        let sec = SecretKey::from_slice(secret)?;
+
+        let context = Secp256k1::new();
+        let pubkey = PublicKey::from_secret_key(&context, &sec);
+        
+        Ok(pubkey.serialize_uncompressed())
+    }
+
+    /// Sign given 32-byte message hash with the key.
+    pub fn sign(secret: &[u8], message: &[u8]) -> Result<(u8, [u8; 64]), Error> {
+        use secp256k1::{SecretKey, Secp256k1, Message};
+        let context = Secp256k1::new();
+
+        let sec = SecretKey::from_slice(secret)?;
+        let msg = Message::from_slice(message)?;
+        let sig = context.sign_recoverable(&msg, &sec);
+
+        let (rec_id, data) = sig.serialize_compact();
+
+        Ok((rec_id.to_i32() as u8, data))
+    }
+
+    /// Recover the signer of the message.
+    pub fn recover(v: u8, r: &[u8; 32], s: &[u8; 32], message: &[u8]) -> Result<[u8; 65], Error> {
+        use secp256k1::{RecoverableSignature, Message, RecoveryId, Secp256k1};
+
+        let mut data = [0u8; 64];
+        data[0..32].copy_from_slice(r);
+        data[32..64].copy_from_slice(s);
+
+        let context = Secp256k1::new();
+        let sig = RecoverableSignature::from_compact(&data, RecoveryId::from_i32(v as i32)?)?;
+        let msg = Message::from_slice(message)?;
+        let pubkey = context.recover(&msg, &sig)?;
+        
+        Ok(pubkey.serialize_uncompressed())
+    }
+}
+
+#[cfg(not(feature = "secp256k1-c"))]
+#[cfg(feature = "secp256k1-rs")]
+mod secp256k1 {
+    use std::fmt;
+
+    pub struct Error(libsecp256k1::Error);
+
+    pub fn verify_secret(secret: &[u8]) -> Result<(), Error> {
+        libsecp256k1::SecretKey::parse_slice(secret)?;
+        Ok(())
+    }
+
+    pub fn secret_to_public(secret: &[u8]) -> Result<[u8; 65], Error> {
+        use libsecp256k1::{SecretKey, PublicKey};
+        let sec = SecretKey::parse_slice(secret)?;
+
+        let pubkey = PublicKey::from_secret_key(&sec);
+        
+        Ok(pubkey.serialize())
+    }
+
+    /// Sign given 32-byte message hash with the key.
+    pub fn sign(secret: &[u8], message: &[u8]) -> Result<(u8, [u8; 64]), Error> {
+        use libsecp256k1::{SecretKey, Message};
+
+        let sec = SecretKey::parse_slice(secret)?;
+        let msg = Message::parse_slice(message)?;
+
+        let (sig, rec_id) = libsecp256k1::sign(&msg, &sec)?;
+
+        Ok((rec_id.serialize(), sig.serialize()))
+    }
+
+    /// Recover the signer of the message.
+    pub fn recover(v: u8, r: &[u8; 32], s: &[u8; 32], message: &[u8]) -> Result<[u8; 65], Error> {
+        use libsecp256k1::{RecoveryId, Signature, Message};
+
+        let mut data = [0u8; 64];
+        data[0..32].copy_from_slice(r);
+        data[32..64].copy_from_slice(s);
+
+        let rec_id = RecoveryId::parse(v)?;
+        let sig = Signature::parse(&data);
+        let msg = Message::parse_slice(message)?;
+        let pubkey = libsecp256k1::recover(&msg, &sig, &rec_id)?;
+        
+        Ok(pubkey.serialize())
+    }
+
+    impl From<libsecp256k1::Error> for Error {
+        fn from(err: libsecp256k1::Error) -> Error {
+            Error(err)
+        }
+    }
+
+    impl fmt::Debug for Error {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fmt::Debug::fmt(&self.0, f)
+        }
+    }
+
+    impl fmt::Display for Error {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fmt::Debug::fmt(&self.0, f)
+        }
+    }
+}

--- a/src/ec.rs
+++ b/src/ec.rs
@@ -1,7 +1,8 @@
 pub use self::secp256k1::*;
 
 #[cfg(feature = "secp256k1-c")]
-pub mod secp256k1 {
+mod secp256k1 {
+    /// Alias type for `secp256k1::Error`
     pub type Error = secp256k1::Error;
 
     pub fn verify_secret(secret: &[u8]) -> Result<(), Error> {
@@ -55,6 +56,7 @@ pub mod secp256k1 {
 mod secp256k1 {
     use std::fmt;
 
+    /// Wrapper type around `libsecp256k1::Error`
     pub struct Error(libsecp256k1::Error);
 
     pub fn verify_secret(secret: &[u8]) -> Result<(), Error> {

--- a/src/ec.rs
+++ b/src/ec.rs
@@ -54,10 +54,8 @@ mod secp256k1 {
 #[cfg(not(feature = "secp256k1-c"))]
 #[cfg(feature = "secp256k1-rs")]
 mod secp256k1 {
-    use std::fmt;
-
-    /// Wrapper type around `libsecp256k1::Error`
-    pub struct Error(libsecp256k1::Error);
+    /// Alias type for `libsecp256k1::Error`
+    pub type Error = libsecp256k1::Error;
 
     pub fn verify_secret(secret: &[u8]) -> Result<(), Error> {
         libsecp256k1::SecretKey::parse_slice(secret)?;
@@ -99,23 +97,5 @@ mod secp256k1 {
         let pubkey = libsecp256k1::recover(&msg, &sig, &rec_id)?;
         
         Ok(pubkey.serialize())
-    }
-
-    impl From<libsecp256k1::Error> for Error {
-        fn from(err: libsecp256k1::Error) -> Error {
-            Error(err)
-        }
-    }
-
-    impl fmt::Debug for Error {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            fmt::Debug::fmt(&self.0, f)
-        }
-    }
-
-    impl fmt::Display for Error {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            fmt::Debug::fmt(&self.0, f)
-        }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,32 @@
+//! The error type
+
+use crate::ec;
+
+/// Key error
+#[derive(Debug)]
+pub enum Error {
+    /// Invalid password for the keyfile
+    InvalidPassword,
+    /// Crypto error
+    Crypto(parity_crypto::Error),
+    /// Secp256k1 error
+    Secp256k1(crate::ec::Error),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            Error::InvalidPassword => write!(fmt, "Invalid Password"),
+            Error::Crypto(ref e) => write!(fmt, "Crypto: {}", e),
+            Error::Secp256k1(ref e) => write!(fmt, "Secp256k1: {:?}", e),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl From<ec::Error> for Error {
+	fn from(e: ec::Error) -> Error {
+		Error::Secp256k1(e)
+	}
+}

--- a/src/key.rs
+++ b/src/key.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use crate::ec;
 use crate::keyfile::KeyFile;
 use crate::protected::Protected;
+use crate::error::Error;
 use rustc_hex::ToHex;
 
 /// Message signature
@@ -86,29 +87,6 @@ pub struct SecretKey {
     secret: Protected,
 }
 
-/// Key error
-#[derive(Debug)]
-pub enum Error {
-    /// Invalid password for the keyfile
-    InvalidPassword,
-    /// Crypto error
-    Crypto(parity_crypto::Error),
-    /// Secp256k1 error
-    Secp256k1(ec::Error),
-}
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match *self {
-            Error::InvalidPassword => write!(fmt, "Invalid Password"),
-            Error::Crypto(ref e) => write!(fmt, "Crypto: {}", e),
-            Error::Secp256k1(ref e) => write!(fmt, "Secp256k1: {}", e),
-        }
-    }
-}
-
-impl std::error::Error for Error {}
-
 impl SecretKey {
     /// Convert a raw bytes secret into Key
     pub fn from_raw(slice: &[u8]) -> Result<Self, ec::Error> {
@@ -146,11 +124,6 @@ impl SecretKey {
         s.copy_from_slice(&data[32..64]);
 
         Ok(Signature { v, r, s })
-    }
-
-    /// Get the underlying 32 byte slice of the secret key
-    pub fn as_bytes(&self) -> &[u8] {
-        &self.secret.0
     }
 }
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -172,6 +172,11 @@ impl SecretKey {
 
         Ok(Signature { v, r, s })
     }
+
+    /// Get the underlying 32 byte slice of the secret key
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.secret.0
+    }
 }
 
 #[cfg(test)]

--- a/src/keyfile.rs
+++ b/src/keyfile.rs
@@ -3,7 +3,7 @@
 use std::num::NonZeroU32;
 use parity_crypto::Keccak256;
 use crate::Protected;
-use crate::key::Error;
+use crate::error::Error;
 
 use serde::{Serialize, Deserialize};
 use rand::{thread_rng, RngCore};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,4 +11,3 @@ pub mod keyfile;
 pub use self::ec::Error;
 pub use self::key::{PublicKey, SecretKey, Signature};
 pub use self::protected::Protected;
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,13 +2,13 @@
 
 #![warn(missing_docs)]
 
-pub(crate) mod ec;
-
+mod ec;
 mod key;
 mod protected;
 
 pub mod keyfile;
 
+pub use self::ec::Error;
 pub use self::key::{PublicKey, SecretKey, Signature};
 pub use self::protected::Protected;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,12 +2,13 @@
 
 #![warn(missing_docs)]
 
+mod error;
 mod ec;
 mod key;
 mod protected;
 
 pub mod keyfile;
 
-pub use self::ec::Error;
+pub use self::error::Error;
 pub use self::key::{PublicKey, SecretKey, Signature};
 pub use self::protected::Protected;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 
 #![warn(missing_docs)]
 
+pub(crate) mod ec;
+
 mod key;
 mod protected;
 

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,13 @@
+echo ""
+echo "Running with C implementation of secp256k1"
+echo "=========================================="
+echo ""
+cargo build || exit
+cargo test || exit
+
+echo ""
+echo "Running with Rust implementation of secp256k1"
+echo "============================================="
+echo ""
+cargo build --no-default-features --features secp256k1-rs || exit
+cargo test --no-default-features --features secp256k1-rs || exit


### PR DESCRIPTION
- The `secp256k1` crate is now an optional dependency, enabled by the default `secp256k1-c` feature.
- Added `libsecp256k1` as an option optional dependency, enabled by the `secp256k-rs` feature.
- Abstracted out all necessary `secp256k1` functions to an `ec` module that operates on raw slices/arrays with one notable exception being the `Error` type that remains specific to underlying `secp256k1` implementation.
- Added the same implementation for the pure Rust `libsecp256k1` crate.
- Added `test.sh` to run unit tests on both crates, `.travis.yml` updated accordingly.
- The `Error` type from `key.rs` is now in it's own module, re-exported at the top level of the library.

Unrelated, but needed for the signer:

+ Added `Crypto::decrypt` to decrypt raw data (`SecretKey::from_keyfile` is now using it internally).
+ Added `Crypto::encrypt` to encrypt raw data.
+ **BREAKING** `SecretKey::from_keyfile` now takes `KeyFile` by reference instead of moving it.