### PR TITLE
Convert from and to Crypto.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/tomusdrw/ethsign"
 license = "GPL-3.0"
 name = "ethsign"
 repository = "https://github.com/tomusdrw/ethsign"
-version = "0.3.0"
+version = "0.4.0"
 
 [dependencies]
 libsecp256k1 = { package = "libsecp256k1", version = "0.2.2", optional = true }


### PR DESCRIPTION
Closes #10 (not entirely but as much as we want to support it).

@maciejhirsz I wonder if `Crypto::encrypt` and `Crypto::decrypt` should now be `pub(crate)` since they deal with raw bytes. What's your thoughts on this?