### PR TITLE
Bump ethsign-crypto.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/tomusdrw/ethsign"
 license = "GPL-3.0"
 name = "ethsign"
 repository = "https://github.com/tomusdrw/ethsign"
-version = "0.7.1"
+version = "0.7.2"
 
 [dependencies]
 zeroize = "0.10.0"
@@ -19,7 +19,7 @@ serde = { version = "1.0", features = ["derive"]}
 
 # Libraries for for pure-rust crypto
 libsecp256k1 = { package="libsecp256k1", version = "0.2.2", optional = true }
-ethsign-crypto = { version = "0.1", path = "./ethsign-crypto", optional = true }
+ethsign-crypto = { version = "0.2", path = "./ethsign-crypto", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/ethsign-crypto/Cargo.toml
+++ b/ethsign-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethsign-crypto"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 documentation = "https://docs.rs/crate/ethsign-crypto"


### PR DESCRIPTION
Resolves #26 

Seems that updated version of `ethsign-crypto` was never released to crates.io