### PR TITLE
Remove parity-crypto dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,14 +7,13 @@ homepage = "https://github.com/tomusdrw/ethsign"
 license = "GPL-3.0"
 name = "ethsign"
 repository = "https://github.com/tomusdrw/ethsign"
-version = "0.8.0"
+version = "0.9.0"
 
 [dependencies]
 zeroize = "1.0.0"
 rand = "0.8.0"
 rustc-hex = "2.0.1"
 secp256k1 = { version = "0.20", optional = true, features = ["recovery"] }
-parity-crypto = { version = "0.9", optional = true }
 serde = { version = "1.0", features = ["derive"]}
 
 # Libraries for for pure-rust crypto
@@ -25,7 +24,7 @@ ethsign-crypto = { version = "0.2.1", path = "./ethsign-crypto", optional = true
 serde_json = "1.0"
 
 [features]
-default = ["secp256k1", "parity-crypto"]
+default = ["secp256k1", "ethsign-crypto"]
 pure-rust = ["libsecp256k1", "ethsign-crypto"]
 
 [workspace]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,12 +32,8 @@ mod error;
 mod key;
 mod protected;
 
-// Use `parity-crypto` by default
-#[cfg(not(feature = "pure-rust"))]
-use parity_crypto as crypto;
-
-// Switch to pure Rust drop-in replacement `ethsign-crypto`
-#[cfg(feature = "pure-rust")]
+// Use pure Rust drop-in replacement `ethsign-crypto` of `parity-crypto`.
+#[cfg(feature = "ethsign-crypto")]
 use ethsign_crypto as crypto;
 
 pub mod keyfile;


### PR DESCRIPTION
Since it's being decommissioned (https://github.com/paritytech/parity-common/pull/566), we stop relying on it and instead use `ethsign-crypto`. I've left the `secp256k1` dependency though.