### PR TITLE
Update `pbkdf2`, `hmac` and `aes`

### DIFF
--- a/ethsign-crypto/Cargo.toml
+++ b/ethsign-crypto/Cargo.toml
@@ -10,11 +10,11 @@ description = "Pure Rust drop-in replacement for the `parity-crypto` crate"
 license = "GPL-3.0"
 
 [dependencies]
-pbkdf2 = { version = "0.7.1", features = [ "parallel" ], default-features = false }
+pbkdf2 = { version = "0.9.0", features = [ "parallel" ], default-features = false }
 scrypt = "0.8.0"
 sha2 = "0.9.1"
-hmac = "0.10.1"
-aes-ctr = "0.6.0"
+hmac = "0.11.0"
+aes = { version = "0.7.5", features = [ "ctr" ], default-features = false }
 tiny-keccak = { version = "2.0.0", features = [ "keccak" ] }
 
 [dev-dependencies]

--- a/ethsign-crypto/src/aes.rs
+++ b/ethsign-crypto/src/aes.rs
@@ -1,8 +1,8 @@
 //! AES symmetric encryption
 
-use aes_ctr::{
-    cipher::{generic_array::GenericArray, NewStreamCipher, SyncStreamCipher},
-    Aes128Ctr,
+use aes::{
+    cipher::{generic_array::GenericArray, FromBlockCipher, NewBlockCipher, StreamCipher},
+    Aes128, Aes128Ctr,
 };
 use std::fmt;
 
@@ -44,8 +44,9 @@ pub fn encrypt_128_ctr(k: &[u8], iv: &[u8], plain: &[u8], dest: &mut [u8]) -> Re
 
     dest.copy_from_slice(plain);
 
-    let mut cipher = Aes128Ctr::new(&key, &nonce);
-    cipher.apply_keystream(dest);
+    let cipher = Aes128::new(&key);
+    let mut cipher_ctr = Aes128Ctr::from_block_cipher(cipher, &nonce);
+    cipher_ctr.apply_keystream(dest);
 
     Ok(())
 }


### PR DESCRIPTION
Update dependencies.

`aes-ctr` is deprecated and thus replaces by `aes`.