### PR TITLE
ethsign dependencies and features update:

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,19 +13,19 @@ version = "0.9.0"
 zeroize = "1.0.0"
 rand = "0.8.0"
 rustc-hex = "2.0.1"
-secp256k1 = { version = "0.21", optional = true, features = ["recovery"] }
+secp256k1 = { version = "0.22", optional = true, features = ["recovery"] }
 serde = { version = "1.0", features = ["derive"]}
 
 # Libraries for for pure-rust crypto
 libsecp256k1 = { package="libsecp256k1", version = "0.7.0", optional = true }
-ethsign-crypto = { version = "0.2.1", path = "./ethsign-crypto", optional = true }
+ethsign-crypto = { version = "0.2.1", path = "./ethsign-crypto" }
 
 [dev-dependencies]
 serde_json = "1.0"
 
 [features]
-default = ["secp256k1", "ethsign-crypto"]
-pure-rust = ["libsecp256k1", "ethsign-crypto"]
+default = ["secp256k1"]
+pure-rust = ["libsecp256k1"]
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1.0", features = ["derive"]}
 
 # Libraries for for pure-rust crypto
 libsecp256k1 = { package="libsecp256k1", version = "0.7.0", optional = true }
-ethsign-crypto = { version = "0.2.1", path = "./ethsign-crypto" }
+ethsign-crypto = { version = "0.2.2", path = "./ethsign-crypto" }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/ethsign-crypto/Cargo.toml
+++ b/ethsign-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethsign-crypto"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 documentation = "https://docs.rs/crate/ethsign-crypto"
@@ -10,8 +10,8 @@ description = "Pure Rust drop-in replacement for the `parity-crypto` crate"
 license = "GPL-3.0"
 
 [dependencies]
-pbkdf2 = { version = "0.10.0", features = [ "parallel" ], default-features = false }
-scrypt = "0.8.0"
+pbkdf2 = { version = "0.11.0", features = [ "parallel" ], default-features = false }
+scrypt = "0.10"
 sha2 = "0.10.1"
 hmac = "0.12.0"
 aes = { version = "0.7.5", features = [ "ctr" ], default-features = false }

--- a/src/ec.rs
+++ b/src/ec.rs
@@ -1,4 +1,9 @@
-pub use self::secp256k1::*;
+//! `secp256k1` implementation module
+
+#[doc(inline)]
+pub use self::secp256k1::Error;
+
+pub(crate) use self::secp256k1::*;
 
 #[cfg(not(feature = "pure-rust"))]
 mod secp256k1 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,8 +32,6 @@ mod error;
 mod key;
 mod protected;
 
-// Use pure Rust drop-in replacement `ethsign-crypto` of `parity-crypto`.
-#[cfg(feature = "ethsign-crypto")]
 use ethsign_crypto as crypto;
 
 pub mod keyfile;


### PR DESCRIPTION
- Update `secp256k1` crate
- re-export ec::Error
- remove ethsign-crypto features
- ethsign-crypto -bump up `scrypt` & `pdkdf2`


Seems reasonable to also export publicly the `ethsign-scrypt::Error` too.